### PR TITLE
Generate graphic reference for effective cover graphic

### DIFF
--- a/xsl/graphicMap2AntCopyScript.xsl
+++ b/xsl/graphicMap2AntCopyScript.xsl
@@ -65,7 +65,7 @@
     <xsl:variable name="targetId" as="xs:string" select="if (@id) then @id else concat('map-item-', position())"/>
     <xsl:variable name="sourceDir" 
       select="relpath:toFile(relpath:getParent(string(@input-url)), $platform)"/>
-    <xsl:if test="false()">
+    <xsl:if test="$debugBoolean">
       <xsl:message> + [DEBUG] graphic-map-item: $sourceDir="<xsl:sequence select="$sourceDir"/>"</xsl:message>
     </xsl:if>
     <xsl:variable name="toFile" select="relpath:toFile(string(@output-url), $platform)" as="xs:string"/>
@@ -73,7 +73,7 @@
       + [INFO]      Input URL: <xsl:sequence select="string(@input-url)"/>
       + [INFO]    Target File: <xsl:sequence select="$toFile"/> 
     </xsl:message>
-    <xsl:if test="false()">    
+    <xsl:if test="$debugBoolean">    
       <xsl:message> + [DEBUG] graphic-map-item: $toFile="<xsl:sequence select="$toFile"/>"</xsl:message>
     </xsl:if>
     

--- a/xsl/map2graphicMap.xsl
+++ b/xsl/map2graphicMap.xsl
@@ -50,6 +50,11 @@
       <xsl:if test="$doDebug">
         <xsl:message> + [DEBUG] ** generate-graphic-map: Additional-graphic-refs done</xsl:message>
       </xsl:if>
+      <xsl:if test="string-length($effectiveCoverGraphicUri) ne 0">
+        <xsl:apply-templates select="." mode="cover-graphic-refs">
+          <xsl:with-param name="effectiveCoverGraphicUri" select="$effectiveCoverGraphicUri"/>
+        </xsl:apply-templates>
+      </xsl:if>
     </xsl:variable>
     
     <xsl:message> + [INFO] Found <xsl:sequence select="count($graphicRefs)"/> graphic references.</xsl:message>
@@ -83,6 +88,15 @@
       </xsl:if>
     </gmap:graphic-map>
     <xsl:message> + [INFO] Graphic input-to-output map generated.</xsl:message>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="cover-graphic-refs">
+    <xsl:param name="effectiveCoverGraphicUri" as="xs:string"/>
+    <gmap:graphic-ref
+      id="{$coverImageId}"
+      href="{$effectiveCoverGraphicUri}"
+      filename="{relpath:getName($effectiveCoverGraphicUri)}"
+      properties="cover-image"/>
   </xsl:template>
   
   <xsl:template mode="generate-graphic-map" match="gmap:graphic-ref">


### PR DESCRIPTION
Current graphic map generation accepts effective cover graphic as a tunnelled parameters, but by default cover graphic is ignored. Users need to add cover graphic processing into their overrides in order to get effective cover graphic included in the graphic map.

This pull-request adds processing to add cover graphic into graphic map when effective cover graphic URI is not-empty. Cover graphic reference is generated using new `cover-graphic-refs` template mode and ID of the reference comes from the existing `$coverImageId` variable.

Also fixed inconsistent debug logging.

Signed-off-by: Jarno Elovirta <jarno.elovirta@wunderdog.fi>